### PR TITLE
Allow specification of report ID in setFeatureReport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,32 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
 
     <groupId>purejavahidapi</groupId>
     <artifactId>purejavahidapi</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
+    <packaging>jar</packaging>
 
     <name>Pure Java HID-API</name>
     <url>https://github.com/nyholku/purejavahidapi</url>
@@ -15,6 +16,7 @@
     </properties>
 
     <build>
+        <sourceDirectory>src</sourceDirectory>
         <plugins> 
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/purejavahidapi/HidDevice.java
+++ b/src/purejavahidapi/HidDevice.java
@@ -137,12 +137,41 @@ abstract public class HidDevice {
 	 * 
 	 * @param data
 	 *            a byte array containing the data to be sent
+         * @param reportId
+         *            a byte specifying the report ID to send
 	 * @param length
 	 *            the number of bytes to send from the data array
 	 * @return number bytes actually sent or -1 if the call failed
 	 * 
 	 */
+        abstract public int setFeatureReport(byte reportId, byte[] data, int length);
 
+	/**
+	 * This method sends a feature report to the device.
+	 * <p>
+	 * See USB HID specification to learn more about feature reports.
+	 * <p>
+	 * This method may or may not block.
+	 * <p>
+	 * The method returning is no guarantee that the data has been physically
+	 * transmitted from the host to the device.
+	 * <p>
+	 * The method returns the actual number of bytes successfully scheduled to
+	 * be sent to the device.
+	 * <p>
+	 * As of this writing it is unclear under what circumstances something else
+	 * than 'length' number of bytes could be returned as well as what happens
+	 * if the report length does not match what the device expects.
+	 * <p>
+	 * 
+	 * @param data
+	 *            a byte array containing the data to be sent
+	 * @param length
+	 *            the number of bytes to send from the data array
+	 * @return number bytes actually sent or -1 if the call failed
+	 * 
+	 */
+        @Deprecated
 	abstract public int setFeatureReport(byte[] data, int length);
 
 	/**

--- a/src/purejavahidapi/HidDevice.java
+++ b/src/purejavahidapi/HidDevice.java
@@ -33,7 +33,7 @@ package purejavahidapi;
  * Instances of HidDevice represent a single physical USB HID device that has
  * been opened for communication.
  * <p>
- * If the {@link HidDevice.close()} has been called for an object then no more
+ * If the {@link HidDevice#close()} has been called for an object then no more
  * call should be made to any of the methods of that object and attempts to do
  * that will result in IllegalState exception being thrown.
  * <p>
@@ -171,7 +171,7 @@ abstract public class HidDevice {
 	 * @return number bytes actually sent or -1 if the call failed
 	 * 
 	 */
-        @Deprecated
+    @Deprecated
 	abstract public int setFeatureReport(byte[] data, int length);
 
 	/**
@@ -227,8 +227,8 @@ abstract public class HidDevice {
 		return m_DeviceRemovalListener;
 	}
 
-/**
-	 * This method returns the same info that the {@link PureJavaHidApi#enumerateDevices()
+    /**
+	 * This method returns the same info that the {@link PureJavaHidApi#enumerateDevices()}
 	 * would return for this device.
 	 * 
 	 * @return the device info object

--- a/src/purejavahidapi/HidDeviceInfo.java
+++ b/src/purejavahidapi/HidDeviceInfo.java
@@ -52,15 +52,14 @@ public class HidDeviceInfo {
 	protected String m_ManufactureString;
 	protected String m_ProductString;
 
-/**
+    /**
 	 * This method returns a string that represents a platform dependent path
 	 * that describes the 'physical' path through hubs and ports to the device.
 	 * <p>
-	 * The main use of the path is to pass it to the
-	 * {@link PureJavaHidApi#openDevice(String) to obtain an instance
-	 * 
-	 * @link HidDevice} which can subsequently be used to communicate with the
-	 *       device.
+	 * The main use of the path is to pass it to the {@link
+	 * PureJavaHidApi#openDevice(HidDeviceInfo)} to obtain a {@link
+	 * HidDevice} instance which can subsequently be used to
+	 * communicate with the device.
 	 * 
 	 * @return a string representing a 'path' to the device
 	 */

--- a/src/purejavahidapi/PureJavaHidApi.java
+++ b/src/purejavahidapi/PureJavaHidApi.java
@@ -43,9 +43,9 @@ import com.sun.jna.Platform;
  * Static methods in PureJavaHidApi allow enumeration and opening of HID
  * devices.
  * <p>
- * {@link #enumerateDevices(int, int)} method returns a iist of HidDeviceInfo
+ * {@link #enumerateDevices()} method returns a iist of HidDeviceInfo
  * objects from which a device path can be obtained. The path can be passed to
- * the {@link #openDevice(String)} method to obtain a {@link HidDevice} object
+ * the {@link #openDevice(HidDeviceInfo path)} method to obtain a {@link HidDevice} object
  * which can then be used to communicate with the device.
  * <p>
  * See javadoc for above mentioned classes and methods for details.

--- a/src/purejavahidapi/linux/HidDevice.java
+++ b/src/purejavahidapi/linux/HidDevice.java
@@ -195,6 +195,16 @@ public class HidDevice extends purejavahidapi.HidDevice {
 	}
 
 	@Override
+	synchronized public int setFeatureReport(byte reportId, byte[] data, int length) {
+		if (!m_Open)
+			throw new IllegalStateException("device not open");
+		byte[] buffer = new byte[length + 1];
+		buffer[0] = reportId;
+		System.arraycopy(data, 0, buffer, 1, length);
+ 		return ioctl(m_DeviceHandle, HIDIOCSFEATURE(length + 1), buffer);
+	}
+
+	@Override
 	synchronized public int setFeatureReport(byte[] data, int length) {
 		if (!m_Open)
 			throw new IllegalStateException("device not open");

--- a/src/purejavahidapi/macosx/HidDevice.java
+++ b/src/purejavahidapi/macosx/HidDevice.java
@@ -278,7 +278,7 @@ public class HidDevice extends purejavahidapi.HidDevice {
 			return -1;
 	}
 
-	private int setReport(int type, byte reporID, byte[] data, int length) {
+	private int setReport(int type, byte reportID, byte[] data, int length) {
 		ByteBuffer data_to_send;
 
 		int length_to_send;
@@ -288,7 +288,7 @@ public class HidDevice extends purejavahidapi.HidDevice {
 		length_to_send = length;
 
 		// On Mac OS X the IOHIDDeviceSetReport() always takes pure data and explicit report number (which maybe 0 if numbers are not used)
-		res = IOHIDDeviceSetReport(m_IOHIDDeviceRef, type, 0xff & reporID, data_to_send, length_to_send);
+		res = IOHIDDeviceSetReport(m_IOHIDDeviceRef, type, 0xff & reportID, data_to_send, length_to_send);
 
 		if (res == kIOReturnSuccess) {
 			return length;
@@ -300,6 +300,12 @@ public class HidDevice extends purejavahidapi.HidDevice {
 		if (!m_Open)
 			throw new IllegalStateException("device not open");
 		return setReport(kIOHIDReportTypeOutput, reportID, data, length);
+	}
+
+	synchronized public int setFeatureReport(byte reportId, byte[] data, int length) {
+		if (!m_Open)
+			throw new IllegalStateException("device not open");
+		return setReport(kIOHIDReportTypeFeature, reportId, data, length);
 	}
 
 	synchronized public int setFeatureReport(byte[] data, int length) {

--- a/src/purejavahidapi/windows/HidDevice.java
+++ b/src/purejavahidapi/windows/HidDevice.java
@@ -181,6 +181,21 @@ public class HidDevice extends purejavahidapi.HidDevice {
 	}
 
 	@Override
+	synchronized public int setFeatureReport(byte reportId, byte[] data, int length) {
+		if (!m_Open)
+			throw new IllegalStateException("device not open");
+		byte[] buffer = new byte[length + 1];
+		buffer[0] = reportId;
+		System.arraycopy(data, 0, buffer, 1, length);
+		if (!HidD_SetFeature(m_Handle, buffer, length + 1)) {
+			//register_error(dev, "HidD_SetFeature");
+			return -1;
+		}
+
+		return length;
+	}
+
+	@Override
 	synchronized public int setFeatureReport(byte[] data, int length) {
 		if (!m_Open)
 			throw new IllegalStateException("device not open");


### PR DESCRIPTION
Fixes #46 

A new API method signature

int setFeatureReport(byte reportId, byte[] data, int length)

was added.

The previous API was marked as deprecated.  It does not work
consistently on MacOS and Linux/Windows in that the MacOS version
always sends feature report 0, whereas the other two take the first
byte of the caller-supplied buffer as the report ID.
