### PR TITLE
Fix duplicate packet

### DIFF
--- a/src/purejavahidapi/windows/HidDevice.java
+++ b/src/purejavahidapi/windows/HidDevice.java
@@ -262,7 +262,10 @@ public class HidDevice extends purejavahidapi.HidDevice {
 					break; // early exit if the device disappears
 				System.out.println("GetOverlappedResult failed with GetLastError()==" + GetLastError());
 			}
-
+			// Avoid duplicate packet
+            		if (m_InputReportOverlapped.Internal != null) {
+            		    	continue;
+            		}
 			if (m_InputReportBytesRead[0] > 0) {
 				byte reportID = m_InputReportMemory.getByte(0);
 				m_InputReportBytesRead[0]--;

--- a/src/purejavahidapi/windows/WinDef.java
+++ b/src/purejavahidapi/windows/WinDef.java
@@ -358,7 +358,7 @@ public class WinDef {
 
 		public OVERLAPPED() {
 
-			setAutoSynch(false);
+			setAutoSynch(true);
 
 		}
 


### PR DESCRIPTION
On Windows (mainly on USB3) duplicate packets are received.
This patch fix this annoying problem.