### PR TITLE
Add usage ID and fix getUsagePage() on macOS

### DIFF
--- a/src/purejavahidapi/HidDeviceInfo.java
+++ b/src/purejavahidapi/HidDeviceInfo.java
@@ -48,6 +48,7 @@ public class HidDeviceInfo {
 	protected short m_ProductId;
 	protected short m_ReleaseNumber;
 	protected short m_UsagePage;
+	protected short m_UsageId;
 	protected String m_SerialNumberString;
 	protected String m_ManufactureString;
 	protected String m_ProductString;
@@ -121,6 +122,20 @@ public class HidDeviceInfo {
 	 */
 	public short getUsagePage() {
 		return m_UsagePage;
+	}
+	
+	/**
+	 * This method returns the 16 bit Usage ID number of the device.
+	 * <p>
+	 * Note that the return type is <code>short</code> so when compared against
+	 * literals or variables of type <code>int</code> sign extension interferes
+	 * and thus it is necessary to cast the <code>int</code> type to
+	 * <code>short</code>
+	 * 
+	 * @return the 16 bit Usage Page number
+	 */
+	public short getUsageId() {
+		return m_UsageId;
 	}
 
 	/**

--- a/src/purejavahidapi/macosx/HidDeviceInfo.java
+++ b/src/purejavahidapi/macosx/HidDeviceInfo.java
@@ -46,8 +46,8 @@ import static purejavahidapi.macosx.HidDevice.*;
 		m_SerialNumberString = getStringProperty(dev, CFSTR(kIOHIDSerialNumberKey));
 		m_ProductString = getStringProperty(dev, CFSTR(kIOHIDProductKey));
 		m_ReleaseNumber = (short) getIntProperty(dev, CFSTR(kIOHIDVersionNumberKey));
-		m_UsagePage = (short) getIntProperty(dev, CFSTR(kIOHIDPrimaryUsageKey));
-
+		m_UsagePage = (short) getIntProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey));
+		m_UsageId = (short) getIntProperty(dev, CFSTR(kIOHIDPrimaryUsageKey));
 	}
 
 }

--- a/src/purejavahidapi/windows/HidDeviceInfo.java
+++ b/src/purejavahidapi/windows/HidDeviceInfo.java
@@ -60,6 +60,7 @@ import com.sun.jna.platform.win32.WinNT.HANDLE;
 			if (HidD_GetPreparsedData(handle, ppd)) {
 				if (HidP_GetCaps(ppd[0], caps) == HIDP_STATUS_SUCCESS) {
 					m_UsagePage = caps.UsagePage;
+					m_UsageId = caps.Usage;
 				}
 
 				HidD_FreePreparsedData(ppd[0]);


### PR DESCRIPTION
On macOS, getUsagePage() was (incorrectly) returning the usage ID. I fixed it and also added a method to get the Usage ID (see https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/hid-usages#usage-id).

Tested on macOS Catalina & Windows 10. No linux implementation as there is no built-in function to get these values and it would require parsing devices' reports manually.