### PR TITLE
Continue to the next device if a device fails to open

### DIFF
--- a/src/purejavahidapi/windows/WindowsBackend.java
+++ b/src/purejavahidapi/windows/WindowsBackend.java
@@ -185,7 +185,7 @@ public class WindowsBackend extends Backend {
 					// recreate as above when opening the device
 					devHandle = openDeviceHandle(path, true);
 					if (devHandle == INVALID_HANDLE_VALUE)
-						break;
+						continue;
 
 					HIDD_ATTRIBUTES attrib = new HIDD_ATTRIBUTES();
 					attrib.Size = new NativeLong(attrib.size());


### PR DESCRIPTION
One of the HID devices on my system can't be opened and this causes all devices after it to be ignored when enumerating devices.